### PR TITLE
docs: fix broken MintPass challenge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,4 +591,4 @@ These settings are configured on the HTTP server, not in the challenge package:
 - bitsocial-js challenge example: `pkc-js/src/runtime/node/community/challenges/bitsocial-js-challenges/captcha-canvas-v3/index.ts`
 - bitsocial-js schemas: `pkc-js/src/community/schema.ts`
 - bitsocial-js challenge orchestration: `pkc-js/src/runtime/node/community/challenges/index.ts`
-- MintPass iframe challenge: https://github.com/bitsociallabs/mintpass/tree/master/challenge
+- MintPass iframe challenge: https://github.com/bitsocialnet/mintpass/tree/master/challenge


### PR DESCRIPTION
## What

Fixes a broken wrong-org link in `README.md`: the MintPass iframe challenge link pointed at `github.com/bitsociallabs/mintpass` (the `bitsociallabs` org doesn't exist — 404). Repointed to `bitsocialnet/mintpass/tree/master/challenge` (verified to exist).

**Scope:** link correction only — no license or content changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link correction with no runtime, security, or data-handling impact.
> 
> **Overview**
> Updates the **Reference Files** MintPass iframe challenge URL in `README.md` from the non-existent `bitsociallabs` GitHub org to **`bitsocialnet/mintpass`** so the documented example link resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 376894c477b447ee67b86a604b81e8dc5ec14a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->